### PR TITLE
Update DEFAULT_SCENE to use the string type

### DIFF
--- a/hue/device/advanced-hue-group.groovy
+++ b/hue/device/advanced-hue-group.groovy
@@ -30,7 +30,7 @@ import groovy.transform.Field
 @Field static final String  SCENE_MODE_TRIGGER       = 'trigger'
 @Field static final String  SCENE_MODE_SWITCH        = 'switch'
 
-@Field static final Boolean DEFAULT_SCENE            = ''
+@Field static final String  DEFAULT_SCENE            = ''
 @Field static final String  DEFAULT_SCENE_MODE       = 'trigger'
 @Field static final Boolean DEFAULT_SCENE_OFF        = false
 @Field static final Boolean DEFAULT_AUTO_REFRESH     = false


### PR DESCRIPTION
## Problem / Motivation

When I created a new Advanced Hue group, I keep getting this error when running the `on` command for the group:

```
app:892020-12-14 09:30:18.283 pm errorjava.lang.NullPointerException: Cannot get property 'false' on null object on line 1084 (findScene)
```

After a little investigating. I found that `Default Scene` in the preference was using `false` as the default value.